### PR TITLE
Better "No duo autopush message"

### DIFF
--- a/byu_awslogin/adfs_auth.py
+++ b/byu_awslogin/adfs_auth.py
@@ -301,7 +301,7 @@ def _begin_authentication_transaction(duo_host, sid, preferred_factor, preferred
     json_response = response.json()
     if json_response['stat'] != 'OK':
         if json_response['message'] == 'Unknown authentication method.':
-            print("\033[91mGeneric Authenticaion Failure.\n\033[93mAre you enrolled in Duo MFA?\nDid you enable Duo automatic push?\033[0m")
+            print("\033[91mGeneric Authentication Failure.\n\033[93mAre you enrolled in Duo MFA?\nDid you enable Duo automatic push?\033[0m")
             os._exit(1)
         else:    
              raise RuntimeError(

--- a/byu_awslogin/adfs_auth.py
+++ b/byu_awslogin/adfs_auth.py
@@ -8,6 +8,7 @@ from bs4 import BeautifulSoup
 import re
 import lxml.etree as ET
 from urllib.parse import urlparse, parse_qs
+import os
 
 # idpentryurl: The initial url that starts the authentication process.
 adfs_entry_url = 'https://awslogin.byu.edu:443/adfs/ls/IdpInitiatedSignOn.aspx?loginToRp=urn:amazon:webservices'
@@ -300,9 +301,8 @@ def _begin_authentication_transaction(duo_host, sid, preferred_factor, preferred
     json_response = response.json()
     if json_response['stat'] != 'OK':
         if json_response['message'] == 'Unknown authentication method.':
-             raise RuntimeError(
-                 u'Generic Authentication Failure.\nAre you enrolled in Duo MFA?\nDid you enable Duo automatic push?'
-             )
+            print("\033[91mGeneric Authenticaion Failure.\n\033[93mAre you enrolled in Duo MFA?\nDid you enable Duo automatic push?\033[0m")
+            os._exit(1)
         else:    
              raise RuntimeError(
                  u'Cannot begin authentication process. The error response: {}'.format(response.text)

--- a/byu_awslogin/adfs_auth.py
+++ b/byu_awslogin/adfs_auth.py
@@ -299,10 +299,14 @@ def _begin_authentication_transaction(duo_host, sid, preferred_factor, preferred
 
     json_response = response.json()
     if json_response['stat'] != 'OK':
-        raise RuntimeError(
-            u'Cannot begin authentication process. The error response: {}'.format(response.text)
-        )
-
+        if json_response['message'] == 'Unknown authentication method.':
+             raise RuntimeError(
+                 u'Generic Authentication Failure.\nAre you enrolled in Duo MFA?\nDid you enable Duo automatic push?'
+             )
+        else:    
+             raise RuntimeError(
+                 u'Cannot begin authentication process. The error response: {}'.format(response.text)
+             )
     return json_response['response']['txid']
 
 


### PR DESCRIPTION
When a user doesn't have Duo auto-push enabled, currently they are greeted with a Python stack trace and an unhelpful error message. This would change it to:
```
(red text) Generic Authentication Failure.
(yellow text) Are you enrolled in Duo MFA?
(yellow text) Did you enable Duo automatic push?
```

It might be helpful to add additional suggestions - however I am not aware of what those might be.