### PR TITLE
Add ADFS Logout option

### DIFF
--- a/byu_awslogin/index.py
+++ b/byu_awslogin/index.py
@@ -19,10 +19,10 @@ except ImportError:
         raise
 
 
-from .util.data_cache import get_status, load_cached_adfs_auth
+from .util.data_cache import get_status, load_cached_adfs_auth, remove_cached_adfs_auth
 from .login import cached_login, non_cached_login
 
-__VERSION__ = '0.12.4'
+__VERSION__ = '0.12.5'
 
 # Enable VT Mode on windows terminal code from:
 # https://bugs.python.org/issue29059
@@ -43,12 +43,18 @@ if platform.system().lower() == 'windows':
 @click.option('-p', '--profile', default='default', help='Profile to use store credentials. Defaults to default')
 @click.option('--region', default='us-west-2', help="The AWS region you will be hitting")
 @click.option('-s', '--status', is_flag=True, default=False, help='Display current logged in status. Use profile all to see all statuses')
-def cli(account, role, profile, region, status):
+@click.option('--logout', is_flag=True, default=False, help='Logout of ADFS cached session only. Does not log out of any active profiles.')
+def cli(account, role, profile, region, status, logout):
     _ensure_min_python_version()
 
     # Display status and exit if the user specified the "-s" flag
     if status:
         get_status(profile)
+        return
+
+    if logout:
+        remove_cached_adfs_auth()
+        print("{}Terminated ADFS Session{}".format(Colors.yellow, Colors.normal))
         return
 
     # Use cached SAML assertion if already logged in, else login to ADFS

--- a/byu_awslogin/util/data_cache.py
+++ b/byu_awslogin/util/data_cache.py
@@ -19,6 +19,16 @@ def load_cached_adfs_auth():
         return None
 
 
+def remove_cached_adfs_auth():
+    file = _aws_file('credentials')
+    config = _open_config_file(file)
+    section = 'all'
+    if config.has_section(section) and config.has_option(section, 'adfs_auth'):
+        config.remove_option(section, 'adfs_auth')
+        with open(file, 'w') as configfile:
+            config.write(configfile)
+
+
 def cache_adfs_auth(adfs_auth_result):
     _create_aws_dir_if_not_exists()
     file = _aws_file('credentials')

--- a/test/byu_awslogin/test_index.py
+++ b/test/byu_awslogin/test_index.py
@@ -1,5 +1,27 @@
+import pytest
 from byu_awslogin import index
+from click.testing import CliRunner
+from unittest.mock import patch
+from byu_awslogin.util.consoleeffects import Colors
 
 
+@pytest.mark.skip("Not Fully Tested")
 def test_cli():
     print("I NEED TO BE TESTED!")
+
+
+@patch('byu_awslogin.index.get_status')
+def test_cli_status(mock_status):
+    results = CliRunner().invoke(index.cli, ['-s'])
+
+    assert results.exit_code == 0
+    assert mock_status.call_count == 1
+
+
+@patch('byu_awslogin.index.remove_cached_adfs_auth')
+def test_cli_logout(mock_remove_adfs):
+    results = CliRunner().invoke(index.cli, ['--logout'])
+
+    assert results.exit_code == 0
+    assert results.output.strip() == "{}Terminated ADFS Session{}".format(Colors.yellow, Colors.normal)
+    assert mock_remove_adfs.call_count == 1

--- a/test/byu_awslogin/util/test_data_cache.py
+++ b/test/byu_awslogin/util/test_data_cache.py
@@ -8,6 +8,7 @@ from byu_awslogin.util import data_cache
 
 tmp_aws_dir = "{}/.aws".format(tempfile.gettempdir())
 
+
 def setup_module(module):
     os.makedirs(tmp_aws_dir)
 
@@ -33,6 +34,26 @@ def test_cache_adfs_auth(mock_exists, mock_aws_file):
     data_cache.cache_adfs_auth(test_adfs_auth_val)
 
     assert test_adfs_auth_val == data_cache.load_cached_adfs_auth()
+
+
+@patch('byu_awslogin.util.data_cache._aws_file')
+@patch('byu_awslogin.util.data_cache.os.path.exists')
+def test_remove_cached_adfs_auth(mock_exists, mock_aws_file):
+    mock_exists.return_value = True
+    creds_file = "{}/credentials".format(tmp_aws_dir)
+    mock_aws_file.return_value = creds_file
+
+    test_adfs_auth_val = b"testing\ntesting"
+    data_cache.cache_adfs_auth(test_adfs_auth_val)
+    data_cache.remove_cached_adfs_auth()
+
+    written_config = read_config_file(creds_file)
+
+    assert mock_exists.call_count == 1
+    assert mock_aws_file.call_count == 2
+    assert not written_config.has_option('all', 'adfs_auth')
+
+
 
 @patch('byu_awslogin.util.data_cache._aws_file')
 @patch('byu_awslogin.util.data_cache.os.path.exists')

--- a/test/byu_awslogin/util/test_data_cache.py
+++ b/test/byu_awslogin/util/test_data_cache.py
@@ -54,7 +54,6 @@ def test_remove_cached_adfs_auth(mock_exists, mock_aws_file):
     assert not written_config.has_option('all', 'adfs_auth')
 
 
-
 @patch('byu_awslogin.util.data_cache._aws_file')
 @patch('byu_awslogin.util.data_cache.os.path.exists')
 def test_write_to_cred_file(mock_exists, mock_aws_file):
@@ -71,9 +70,9 @@ def test_write_to_cred_file(mock_exists, mock_aws_file):
     assert mock_exists.call_count == 1
     assert mock_aws_file.call_count == 1
     assert written_config['default'] == {'aws_access_key_id': 'keyid',
-                                 'aws_secret_access_key': 'secretkey',
-                                 'aws_session_token': 'sessiontoken'
-                                 }
+                                         'aws_secret_access_key': 'secretkey',
+                                         'aws_session_token': 'sessiontoken'
+                                         }
 
 
 @patch('byu_awslogin.util.data_cache._aws_file')
@@ -105,7 +104,7 @@ def test_load_last_netid(mock_open_config_file):
     mock_config_file = mock_open_config_file.return_value = MagicMock()
     mock_config_file.has_section.return_value = True
     mock_config_file.has_option.return_value = True
-    d = { 'default' : {'adfs_netid': 'fake_netid'}}
+    d = {'default': {'adfs_netid': 'fake_netid'}}
     mock_config_file.__getitem__.side_effect = d.__getitem__
 
     profile = "default"


### PR DESCRIPTION
This adds a --logout option that removes the ADFS session information so a different account can be used.

It should be noted that as implemented here so far this doesn't logout of any active sessions to AWS. It only removes the ADFS session.

resolves #29 