### PR TITLE
Increase timeout for ADFS role to 9 hours

### DIFF
--- a/byu_awslogin/auth/assume_role.py
+++ b/byu_awslogin/auth/assume_role.py
@@ -41,7 +41,7 @@ def assume_role(account_role, samlAssertion):
         RoleArn=account_role.role_arn,
         PrincipalArn=account_role.principal_arn,
         SAMLAssertion=samlAssertion,
-        DurationSeconds=3600,
+        DurationSeconds=28800, # Valid for 8 hours
     )
 
     return aws_session_token

--- a/byu_awslogin/index.py
+++ b/byu_awslogin/index.py
@@ -25,7 +25,7 @@ except ImportError:
 from .util.data_cache import get_status, load_cached_adfs_auth, remove_cached_adfs_auth
 from .login import cached_login, non_cached_login
 
-__VERSION__ = '0.13.3'
+__VERSION__ = '0.13.4'
 
 # Enable VT Mode on windows terminal code from:
 # https://bugs.python.org/issue29059


### PR DESCRIPTION
Timeouts of SAML-based temporary sessions may now be up to 12 hours.

SWAT has decided to increase this timeout to 9 hours. Terraform doesn't support this feature yet, so we had to update our role max timeouts manually using a script. See https://github.com/byu-oit/byu-acs/issues/174 for this issue.